### PR TITLE
Fix Typescript compatibility with field components

### DIFF
--- a/src/components/VuetableColGroup.vue
+++ b/src/components/VuetableColGroup.vue
@@ -34,7 +34,7 @@ export default {
 
   methods: {
     columnClass (field, fieldIndex) {
-      let fieldName = typeof(field.name) === "object" && field.name !== null
+      let fieldName = (typeof(field.name) === "object" || typeof(field.name) === "function") && field.name !== null
         ? field.name.name
         : field.name
       fieldName = fieldName.replace(this.fieldPrefix, "")


### PR DESCRIPTION
In Typescript, export of Vue component returns type = function by default. This causes issues when trying to use field components because fieldName.replace in VuetableColGroup only checks for object type and returns "fieldName.replace is not a function".

Example method signature that causes issues:

export default class VuetableCustomCheckbox extends Vue {
  ...
}